### PR TITLE
ci(gravity): track `dist/index.js` instead of `index.js`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run bundle
-      - run: npm run gravity './index.js'
+      - run: npm run gravity './dist/index.js'
         env:
           GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}


### PR DESCRIPTION
<!--
  This pull request template provides suggested sections for framing your work.
  You're welcome to change or remove headers if it doesn't fit your use case. :) 
-->

### What are you trying to accomplish?
To measure the result of bundling the library in Gravity, not the `index.js` before bundling.
